### PR TITLE
Build improvements

### DIFF
--- a/Asterisk_1.2/Makefile
+++ b/Asterisk_1.2/Makefile
@@ -47,7 +47,6 @@ all: $(RES)
 	@echo ""
 
 $(NAME).so : $(NAME).o
-	echo $(ASTERISK_INCLUDE_DIR)
 	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 missing_includes:

--- a/Asterisk_1.2/Makefile
+++ b/Asterisk_1.2/Makefile
@@ -62,7 +62,7 @@ install: all
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
-		install -m 755 $(NAME).so $(MODULES_DIR) ; \
+		install -m 755 $(NAME).so $(ASTERISK_MODULES_DIR) ; \
 	fi
 
 reload: install

--- a/Asterisk_1.2/Makefile
+++ b/Asterisk_1.2/Makefile
@@ -1,40 +1,65 @@
 #  app_swift -- A Cepstral Swift TTS engine interface
 # 
-#  Copyright (C) 2006 - 2010, Darren Sessions
+#  Copyright (C) 2006 - 2011, Darren Sessions
 # 
 #  Darren Sessions <darrensessions@me.com>
+#
+#  http://www.twitter.com/darrensessions
+#  http://www.linkedin.com/in/dsessions
 # 
 #  This program is free software, distributed under the
 #  terms of the GNU General Public License Version 2. See
 #  the LICENSE file at the top of the source tree for more
 #  information.
- 
 
 NAME=app_swift
 CONF=swift.conf
 
 CC=gcc
 OSARCH=$(shell uname -s)
+ASTERISK_ROOT_DIR=/usr
+ASTERISK_LIB_DIR=$(ASTERISK_ROOT_DIR)/lib
+ASTERISK_MODULES_DIR=$(ASTERISK_LIB_DIR)/asterisk/modules
+ASTERISK_INCLUDE_DIR=$(ASTERISK_ROOT_DIR)/include
+ASTERISK_CONFIG_DIR=/etc/asterisk
 
 SWIFT_DIR=/opt/swift
-CFLAGS=-I${SWIFT_DIR}/include -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
-LDFLAGS=-L${SWIFT_DIR}/lib -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
+CFLAGS=-I${SWIFT_DIR}/include -I${ASTERISK_INCLUDE_DIR} -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
+LDFLAGS=-L${SWIFT_DIR}/lib -L${ASTERISK_LIB_DIR} -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
 SOLINK=-shared -Xlinker -x
 
-RES=$(shell if [ -f /usr/include/asterisk/channel.h ]; then echo "$(NAME).so"; fi)
+RES=$(shell if [ -f $(ASTERISK_INCLUDE_DIR)/asterisk/channel.h ]; then echo "$(NAME).so"; else echo "missing_includes"; fi)
 
-MODULES_DIR=/usr/lib/asterisk/modules
-
-$(NAME).so : $(NAME).o
-	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 all: $(RES)
+	@echo ""
+	@echo ""
+	@echo "                                         _    ___         "
+	@echo "                                        (_)  / __)  _     "
+	@echo "    _____ ____  ____           ___ _ _ _ _ _| |__ _| |_   "
+	@echo "   (____ |  _ \|  _ \         /___) | | | (_   __|_   _)  "
+	@echo "   / ___ | |_| | |_| | ____  |___ | | | | | | |    | |_   "
+	@echo "   \_____|  __/|  __/ (____) |___/ \___/|_| |_|     \__)  "
+	@echo "         |_|   |_|                                        "
+	@echo "  ********************************************************"
+	@echo "  *  Run 'make install' to install the app_swift module. *"
+	@echo "  ********************************************************"
+	@echo ""
+
+$(NAME).so : $(NAME).o
+	echo $(ASTERISK_INCLUDE_DIR)
+	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
+
+missing_includes:
+	@echo "Could not locate Asterisk include files."
+	@echo "Try re-running with 'make ASTERISK_ROOT_DIR=/path/to/asterisk'"
+	@exit 1
 
 clean:
 	rm -f $(NAME).o $(NAME).so
 
 install: all
-	if ! [ -f /etc/asterisk/$(CONF) ]; then \
+	if ! [ -f $(ASTERISK_CONFIG_DIR)/$(CONF) ]; then \
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
@@ -44,4 +69,3 @@ install: all
 reload: install
 	asterisk -rx "module unload ${RES}"
 	asterisk -rx "module load ${RES}"
-

--- a/Asterisk_1.4/Makefile
+++ b/Asterisk_1.4/Makefile
@@ -47,7 +47,6 @@ all: $(RES)
 	@echo ""
 
 $(NAME).so : $(NAME).o
-	echo $(ASTERISK_INCLUDE_DIR)
 	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 missing_includes:

--- a/Asterisk_1.4/Makefile
+++ b/Asterisk_1.4/Makefile
@@ -62,7 +62,7 @@ install: all
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
-		install -m 755 $(NAME).so $(MODULES_DIR) ; \
+		install -m 755 $(NAME).so $(ASTERISK_MODULES_DIR) ; \
 	fi
 
 reload: install

--- a/Asterisk_1.4/Makefile
+++ b/Asterisk_1.4/Makefile
@@ -1,40 +1,65 @@
 #  app_swift -- A Cepstral Swift TTS engine interface
 # 
-#  Copyright (C) 2006 - 2010, Darren Sessions
+#  Copyright (C) 2006 - 2011, Darren Sessions
 # 
 #  Darren Sessions <darrensessions@me.com>
+#
+#  http://www.twitter.com/darrensessions
+#  http://www.linkedin.com/in/dsessions
 # 
 #  This program is free software, distributed under the
 #  terms of the GNU General Public License Version 2. See
 #  the LICENSE file at the top of the source tree for more
 #  information.
- 
 
 NAME=app_swift
 CONF=swift.conf
 
 CC=gcc
 OSARCH=$(shell uname -s)
+ASTERISK_ROOT_DIR=/usr
+ASTERISK_LIB_DIR=$(ASTERISK_ROOT_DIR)/lib
+ASTERISK_MODULES_DIR=$(ASTERISK_LIB_DIR)/asterisk/modules
+ASTERISK_INCLUDE_DIR=$(ASTERISK_ROOT_DIR)/include
+ASTERISK_CONFIG_DIR=/etc/asterisk
 
 SWIFT_DIR=/opt/swift
-CFLAGS=-I${SWIFT_DIR}/include -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
-LDFLAGS=-L${SWIFT_DIR}/lib -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
+CFLAGS=-I${SWIFT_DIR}/include -I${ASTERISK_INCLUDE_DIR} -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
+LDFLAGS=-L${SWIFT_DIR}/lib -L${ASTERISK_LIB_DIR} -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
 SOLINK=-shared -Xlinker -x
 
-RES=$(shell if [ -f /usr/include/asterisk/channel.h ]; then echo "$(NAME).so"; fi)
+RES=$(shell if [ -f $(ASTERISK_INCLUDE_DIR)/asterisk/channel.h ]; then echo "$(NAME).so"; else echo "missing_includes"; fi)
 
-MODULES_DIR=/usr/lib/asterisk/modules
-
-$(NAME).so : $(NAME).o
-	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 all: $(RES)
+	@echo ""
+	@echo ""
+	@echo "                                         _    ___         "
+	@echo "                                        (_)  / __)  _     "
+	@echo "    _____ ____  ____           ___ _ _ _ _ _| |__ _| |_   "
+	@echo "   (____ |  _ \|  _ \         /___) | | | (_   __|_   _)  "
+	@echo "   / ___ | |_| | |_| | ____  |___ | | | | | | |    | |_   "
+	@echo "   \_____|  __/|  __/ (____) |___/ \___/|_| |_|     \__)  "
+	@echo "         |_|   |_|                                        "
+	@echo "  ********************************************************"
+	@echo "  *  Run 'make install' to install the app_swift module. *"
+	@echo "  ********************************************************"
+	@echo ""
+
+$(NAME).so : $(NAME).o
+	echo $(ASTERISK_INCLUDE_DIR)
+	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
+
+missing_includes:
+	@echo "Could not locate Asterisk include files."
+	@echo "Try re-running with 'make ASTERISK_ROOT_DIR=/path/to/asterisk'"
+	@exit 1
 
 clean:
 	rm -f $(NAME).o $(NAME).so
 
 install: all
-	if ! [ -f /etc/asterisk/$(CONF) ]; then \
+	if ! [ -f $(ASTERISK_CONFIG_DIR)/$(CONF) ]; then \
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
@@ -44,4 +69,3 @@ install: all
 reload: install
 	asterisk -rx "module unload ${RES}"
 	asterisk -rx "module load ${RES}"
-

--- a/Asterisk_1.6/Makefile
+++ b/Asterisk_1.6/Makefile
@@ -47,7 +47,6 @@ all: $(RES)
 	@echo ""
 
 $(NAME).so : $(NAME).o
-	echo $(ASTERISK_INCLUDE_DIR)
 	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 missing_includes:

--- a/Asterisk_1.6/Makefile
+++ b/Asterisk_1.6/Makefile
@@ -62,7 +62,7 @@ install: all
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
-		install -m 755 $(NAME).so $(MODULES_DIR) ; \
+		install -m 755 $(NAME).so $(ASTERISK_MODULES_DIR) ; \
 	fi
 
 reload: install

--- a/Asterisk_1.6/Makefile
+++ b/Asterisk_1.6/Makefile
@@ -1,40 +1,65 @@
 #  app_swift -- A Cepstral Swift TTS engine interface
 # 
-#  Copyright (C) 2006 - 2010, Darren Sessions
+#  Copyright (C) 2006 - 2011, Darren Sessions
 # 
 #  Darren Sessions <darrensessions@me.com>
+#
+#  http://www.twitter.com/darrensessions
+#  http://www.linkedin.com/in/dsessions
 # 
 #  This program is free software, distributed under the
 #  terms of the GNU General Public License Version 2. See
 #  the LICENSE file at the top of the source tree for more
 #  information.
- 
 
 NAME=app_swift
 CONF=swift.conf
 
 CC=gcc
 OSARCH=$(shell uname -s)
+ASTERISK_ROOT_DIR=/usr
+ASTERISK_LIB_DIR=$(ASTERISK_ROOT_DIR)/lib
+ASTERISK_MODULES_DIR=$(ASTERISK_LIB_DIR)/asterisk/modules
+ASTERISK_INCLUDE_DIR=$(ASTERISK_ROOT_DIR)/include
+ASTERISK_CONFIG_DIR=/etc/asterisk
 
 SWIFT_DIR=/opt/swift
-CFLAGS=-I${SWIFT_DIR}/include -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
-LDFLAGS=-L${SWIFT_DIR}/lib -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
+CFLAGS=-I${SWIFT_DIR}/include -I${ASTERISK_INCLUDE_DIR} -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
+LDFLAGS=-L${SWIFT_DIR}/lib -L${ASTERISK_LIB_DIR} -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
 SOLINK=-shared -Xlinker -x
 
-RES=$(shell if [ -f /usr/include/asterisk/channel.h ]; then echo "$(NAME).so"; fi)
+RES=$(shell if [ -f $(ASTERISK_INCLUDE_DIR)/asterisk/channel.h ]; then echo "$(NAME).so"; else echo "missing_includes"; fi)
 
-MODULES_DIR=/usr/lib/asterisk/modules
-
-$(NAME).so : $(NAME).o
-	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 all: $(RES)
+	@echo ""
+	@echo ""
+	@echo "                                         _    ___         "
+	@echo "                                        (_)  / __)  _     "
+	@echo "    _____ ____  ____           ___ _ _ _ _ _| |__ _| |_   "
+	@echo "   (____ |  _ \|  _ \         /___) | | | (_   __|_   _)  "
+	@echo "   / ___ | |_| | |_| | ____  |___ | | | | | | |    | |_   "
+	@echo "   \_____|  __/|  __/ (____) |___/ \___/|_| |_|     \__)  "
+	@echo "         |_|   |_|                                        "
+	@echo "  ********************************************************"
+	@echo "  *  Run 'make install' to install the app_swift module. *"
+	@echo "  ********************************************************"
+	@echo ""
+
+$(NAME).so : $(NAME).o
+	echo $(ASTERISK_INCLUDE_DIR)
+	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
+
+missing_includes:
+	@echo "Could not locate Asterisk include files."
+	@echo "Try re-running with 'make ASTERISK_ROOT_DIR=/path/to/asterisk'"
+	@exit 1
 
 clean:
 	rm -f $(NAME).o $(NAME).so
 
 install: all
-	if ! [ -f /etc/asterisk/$(CONF) ]; then \
+	if ! [ -f $(ASTERISK_CONFIG_DIR)/$(CONF) ]; then \
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
@@ -44,4 +69,3 @@ install: all
 reload: install
 	asterisk -rx "module unload ${RES}"
 	asterisk -rx "module load ${RES}"
-

--- a/Asterisk_1.8/Makefile
+++ b/Asterisk_1.8/Makefile
@@ -47,7 +47,6 @@ all: $(RES)
 	@echo ""
 
 $(NAME).so : $(NAME).o
-	echo $(ASTERISK_INCLUDE_DIR)
 	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 missing_includes:

--- a/Asterisk_1.8/Makefile
+++ b/Asterisk_1.8/Makefile
@@ -62,7 +62,7 @@ install: all
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
-		install -m 755 $(NAME).so $(MODULES_DIR) ; \
+		install -m 755 $(NAME).so $(ASTERISK_MODULES_DIR) ; \
 	fi
 
 reload: install

--- a/Asterisk_1.8/Makefile
+++ b/Asterisk_1.8/Makefile
@@ -1,40 +1,65 @@
 #  app_swift -- A Cepstral Swift TTS engine interface
 # 
-#  Copyright (C) 2006 - 2010, Darren Sessions
+#  Copyright (C) 2006 - 2011, Darren Sessions
 # 
 #  Darren Sessions <darrensessions@me.com>
+#
+#  http://www.twitter.com/darrensessions
+#  http://www.linkedin.com/in/dsessions
 # 
 #  This program is free software, distributed under the
 #  terms of the GNU General Public License Version 2. See
 #  the LICENSE file at the top of the source tree for more
 #  information.
- 
 
 NAME=app_swift
 CONF=swift.conf
 
 CC=gcc
 OSARCH=$(shell uname -s)
+ASTERISK_ROOT_DIR=/usr
+ASTERISK_LIB_DIR=$(ASTERISK_ROOT_DIR)/lib
+ASTERISK_MODULES_DIR=$(ASTERISK_LIB_DIR)/asterisk/modules
+ASTERISK_INCLUDE_DIR=$(ASTERISK_ROOT_DIR)/include
+ASTERISK_CONFIG_DIR=/etc/asterisk
 
 SWIFT_DIR=/opt/swift
-CFLAGS=-I${SWIFT_DIR}/include -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
-LDFLAGS=-L${SWIFT_DIR}/lib -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
+CFLAGS=-I${SWIFT_DIR}/include -I${ASTERISK_INCLUDE_DIR} -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC
+LDFLAGS=-L${SWIFT_DIR}/lib -L${ASTERISK_LIB_DIR} -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
 SOLINK=-shared -Xlinker -x
 
-RES=$(shell if [ -f /usr/include/asterisk/channel.h ]; then echo "$(NAME).so"; fi)
+RES=$(shell if [ -f $(ASTERISK_INCLUDE_DIR)/asterisk/channel.h ]; then echo "$(NAME).so"; else echo "missing_includes"; fi)
 
-MODULES_DIR=/usr/lib/asterisk/modules
-
-$(NAME).so : $(NAME).o
-	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 all: $(RES)
+	@echo ""
+	@echo ""
+	@echo "                                         _    ___         "
+	@echo "                                        (_)  / __)  _     "
+	@echo "    _____ ____  ____           ___ _ _ _ _ _| |__ _| |_   "
+	@echo "   (____ |  _ \|  _ \         /___) | | | (_   __|_   _)  "
+	@echo "   / ___ | |_| | |_| | ____  |___ | | | | | | |    | |_   "
+	@echo "   \_____|  __/|  __/ (____) |___/ \___/|_| |_|     \__)  "
+	@echo "         |_|   |_|                                        "
+	@echo "  ********************************************************"
+	@echo "  *  Run 'make install' to install the app_swift module. *"
+	@echo "  ********************************************************"
+	@echo ""
+
+$(NAME).so : $(NAME).o
+	echo $(ASTERISK_INCLUDE_DIR)
+	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
+
+missing_includes:
+	@echo "Could not locate Asterisk include files."
+	@echo "Try re-running with 'make ASTERISK_ROOT_DIR=/path/to/asterisk'"
+	@exit 1
 
 clean:
 	rm -f $(NAME).o $(NAME).so
 
 install: all
-	if ! [ -f /etc/asterisk/$(CONF) ]; then \
+	if ! [ -f $(ASTERISK_CONFIG_DIR)/$(CONF) ]; then \
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
@@ -44,4 +69,3 @@ install: all
 reload: install
 	asterisk -rx "module unload ${RES}"
 	asterisk -rx "module load ${RES}"
-

--- a/Asterisk_10/Makefile
+++ b/Asterisk_10/Makefile
@@ -47,7 +47,6 @@ all: $(RES)
 	@echo ""
 
 $(NAME).so : $(NAME).o
-	echo $(ASTERISK_INCLUDE_DIR)
 	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
 
 missing_includes:

--- a/Asterisk_10/Makefile
+++ b/Asterisk_10/Makefile
@@ -62,7 +62,7 @@ install:
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \
-		install -m 755 $(NAME).so $(MODULES_DIR) ; \
+		install -m 755 $(NAME).so $(ASTERISK_MODULES_DIR) ; \
 	fi
 
 reload: install

--- a/Asterisk_10/Makefile
+++ b/Asterisk_10/Makefile
@@ -17,15 +17,19 @@ CONF=swift.conf
 
 CC=gcc
 OSARCH=$(shell uname -s)
+ASTERISK_ROOT_DIR=/usr
+ASTERISK_LIB_DIR=$(ASTERISK_ROOT_DIR)/lib
+ASTERISK_MODULES_DIR=$(ASTERISK_LIB_DIR)/asterisk/modules
+ASTERISK_INCLUDE_DIR=$(ASTERISK_ROOT_DIR)/include
+ASTERISK_CONFIG_DIR=/etc/asterisk
 
 SWIFT_DIR=/opt/swift
-CFLAGS=-I${SWIFT_DIR}/include -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC -O3
-LDFLAGS=-L${SWIFT_DIR}/lib -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
+CFLAGS=-I${SWIFT_DIR}/include -I${ASTERISK_INCLUDE_DIR} -g -Wall -D_REENTRANT -D_GNU_SOURCE -fPIC -O3
+LDFLAGS=-L${SWIFT_DIR}/lib -L${ASTERISK_LIB_DIR} -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
 SOLINK=-shared -Xlinker -x
 
-RES=$(shell if [ -f /usr/include/asterisk/channel.h ]; then echo "$(NAME).so"; fi)
+RES=$(shell if [ -f $(ASTERISK_INCLUDE_DIR)/asterisk/channel.h ]; then echo "$(NAME).so"; else echo "missing_includes"; fi)
 
-MODULES_DIR=/usr/lib/asterisk/modules
 
 all: $(RES)
 	@echo ""
@@ -43,13 +47,19 @@ all: $(RES)
 	@echo ""
 
 $(NAME).so : $(NAME).o
+	echo $(ASTERISK_INCLUDE_DIR)
 	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
+
+missing_includes:
+	@echo "Could not locate Asterisk include files."
+	@echo "Try re-running with 'make ASTERISK_ROOT_DIR=/path/to/asterisk'"
+	@exit 1
 
 clean:
 	rm -f $(NAME).o $(NAME).so
 
 install: 
-	if ! [ -f /etc/asterisk/$(CONF) ]; then \
+	if ! [ -f $(ASTERISK_CONFIG_DIR)/$(CONF) ]; then \
 		install -m 644 $(CONF).sample /etc/asterisk/$(CONF) ; \
 	fi
 	if [ -f $(NAME).so ]; then \

--- a/README
+++ b/README
@@ -1,0 +1,29 @@
+                                      _    ___         
+                                     (_)  / __)  _     
+ _____ ____  ____           ___ _ _ _ _ _| |__ _| |_   
+(____ |  _ \|  _ \         /___) | | | (_   __|_   _)  
+/ ___ | |_| | |_| | ____  |___ | | | | | | |    | |_   
+\_____|  __/|  __/ (____) |___/ \___/|_| |_|     \__)  
+      |_|   |_|    
+=====================================================
+
+app_swift - A Cepstral Swift TTS engine interface
+
+Copyright (C) 2006-2011, Darren Sessions
+
+Bug reports, comments, or otherwise can be directed 
+to me at darrensessions@me.com. I welcome any feedback
+or questions.
+
+http://www.twitter.com/darrensessions
+http://www.linkedin.com/in/dsessions
+
+=====================================================
+Visit me on the web at: http://www.darrensessions.com
+=====================================================
+
+This program is free software, distributed under the 
+terms of the GNU General Public License Version 2. 
+Read the LICENSE file for details. 
+
+=====================================================


### PR DESCRIPTION
Two things that help building Asterisk in non-standard environments:
- Allow specifying alternate locations for Asterisk include and configuration files
- Print an error if the include files are not found
