### PR TITLE
Fixed linking order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ all: banner $(AST_INC_CHECK) $(AST_VER_CHECK)
 	@echo ""
 
 $(NAME).so : $(NAME).o
-	$(CC) $(SOLINK) -o $@ $(LDFLAGS) $<
+	$(CC) $(SOLINK) -o $@ $< $(LDFLAGS) 
 
 banner:
 	@echo ""


### PR DESCRIPTION
 Fixed linker order. was not working (at least on ubuntu) fixes error  "undefined symbol: swift_port_close" on loading
