### PR TITLE
Fixed app_swift code to compile in asterisk 14.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -27,7 +27,7 @@ AST_MOD_DIR=$(SYS_LIB_DIR)/asterisk/modules
 AST_INC_DIR=$(SYS_INC_DIR)/asterisk
 AST_CFG_DIR=%%AST_CFG%%
 
-CFLAGS=-I${SWIFT_DIR}/include -I${SYS_INC_DIR} -g -Wall -fPIC
+CFLAGS=-I${SWIFT_DIR}/include -I${SYS_INC_DIR} -g -Wall -fPIC -DAST_MODULE_SELF_SYM="__internal_app_swift"
 LDFLAGS=-L${SWIFT_DIR}/lib -L${SYS_LIB_DIR} -lswift $(patsubst ${SWIFT_DIR}/lib/lib%.so,-l%,$(wildcard ${SWIFT_DIR}/lib/libcep*.so))
 SOLINK=%%SOLINK%%
 

--- a/app_swift.c
+++ b/app_swift.c
@@ -31,7 +31,21 @@
  ***/
 
 #include "asterisk.h"
+
+/**
+ * Backward compatible ASTERISK_REGISTER_FILE() macro.
+ */
+#if !(defined _AST_VER_14)
+#ifndef ASTERISK_REGISTER_FILE
+#define ASTERISK_REGISTER_FILE() ASTERISK_FILE_VERSION(__FILE__, "")
+#endif
+#endif
+
+#if !(defined _AST_VER_14)
 ASTERISK_FILE_VERSION(__FILE__, "$Revision: 304000 $")
+#else
+ASTERISK_REGISTER_FILE()
+#endif
 
 #include <swift.h>
 #if defined _SWIFT_VER_6
@@ -47,7 +61,7 @@ ASTERISK_FILE_VERSION(__FILE__, "$Revision: 304000 $")
 #include "asterisk/app.h"
 #include "asterisk/file.h"
 
-#if (defined _AST_VER_13)
+#if (defined _AST_VER_13 || defined _AST_VER_14)
 #include "asterisk/format_cache.h"
 #endif
 
@@ -290,7 +304,7 @@ static char *listen_for_dtmf(struct ast_channel *chan, int timeout, int max_digi
 
 #if (defined _AST_VER_1_4 || defined _AST_VER_1_6)
 static int app_exec(struct ast_channel *chan, void *data)
-#elif (defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#elif (defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 static int app_exec(struct ast_channel *chan, const char *data)
 #endif
 {
@@ -305,7 +319,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 	char *parse;
 #if (defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12)
 	struct ast_format old_writeformat;
-#elif (defined _AST_VER_13)
+#elif (defined _AST_VER_13 || defined _AST_VER_14)
 	RAII_VAR(struct ast_format *, old_writeformat, NULL, ao2_cleanup);
 #else
 	int old_writeformat = 0;
@@ -427,7 +441,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 		ast_log(LOG_ERROR, "Failed to speak.\n");
 		goto exception;
 	}
-#if (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#if (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 	if (ast_channel_state(chan) != AST_STATE_UP) {
 #else
 	if (chan->_state != AST_STATE_UP) {
@@ -449,7 +463,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 	ast_format_copy(&old_writeformat, ast_channel_writeformat(chan));
 
 	if (ast_set_write_format_by_id(chan, AST_FORMAT_ULAW) < 0) {
-#elif (defined _AST_VER_13)
+#elif (defined _AST_VER_13 || defined _AST_VER_14)
 	old_writeformat = ao2_bump(ast_channel_writeformat(chan));
 
 	if (ast_set_write_format(chan, ast_format_ulaw) < 0) {
@@ -499,7 +513,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 				myf.f.subclass.codec = AST_FORMAT_ULAW;
 #elif (defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12)
 				ast_format_set(&myf.f.subclass.format, AST_FORMAT_ULAW, 0);
-#elif (defined _AST_VER_13)
+#elif (defined _AST_VER_13 || defined _AST_VER_14)
 				myf.f.subclass.format = ast_format_ulaw;
 #endif
 				myf.f.datalen = len;
@@ -553,7 +567,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 					if (f->frametype == AST_FRAME_DTMF && timeout > 0 && max_digits > 0) {
 #if (defined _AST_VER_1_6 || defined _AST_VER_1_4)
 						char originalDTMF = f->subclass;
-#elif (defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#elif (defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 						char originalDTMF = f->subclass.integer;
 #endif
 						alreadyran = 1;
@@ -604,7 +618,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 	}
 	if (max_digits >= 1 && results != NULL) {
 		if (cfg_goto_exten) {
-#if (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#if (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 			ast_log(LOG_NOTICE, "GoTo(%s|%s|%d) : ", ast_channel_context(chan), results, 1);
 #else
 			ast_log(LOG_NOTICE, "GoTo(%s|%s|%d) : ", chan->context, results, 1);
@@ -614,11 +628,11 @@ static int app_exec(struct ast_channel *chan, const char *data)
 			if (ast_exists_extension (chan, chan->context, results, 1, chan->cid.cid_num)) {
 #elif (defined _AST_VER_1_8 || defined _AST_VER_10)
 			 if (ast_exists_extension (chan, chan->context, results, 1, chan->caller.id.number.str)) {
-#elif (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#elif (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 			 if (ast_exists_extension (chan, ast_channel_context(chan), results, 1, ast_channel_caller(chan)->id.number.str)) {
 #endif
 				ast_log(LOG_NOTICE, "OK\n");
-#if (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#if (defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 				ast_channel_exten_set(chan, results);
 				ast_channel_priority_set(chan, 0);
 #else
@@ -655,7 +669,7 @@ static int app_exec(struct ast_channel *chan, const char *data)
 	if (!res) {
 		ast_set_write_format(chan, &old_writeformat);
 	}
-#elif (defined _AST_VER_13)
+#elif (defined _AST_VER_13 || defined _AST_VER_14)
 	if (!res) {
 		ast_set_write_format(chan, old_writeformat);
 	}
@@ -680,7 +694,7 @@ static int load_module(void)
 	int res = 0;
 	const char *val = NULL;
 	struct ast_config *cfg;
-#if  (defined _AST_VER_1_6 || defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#if  (defined _AST_VER_1_6 || defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 	struct ast_flags config_flags = { CONFIG_FLAG_NOCACHE };
 #endif
 
@@ -694,14 +708,14 @@ static int load_module(void)
 
 #if (defined _AST_VER_1_6 || defined _AST_VER_1_4)
 	res = ast_register_application(app, app_exec, synopsis, descrip) ?
-#elif (defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#elif (defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 	res = ast_register_application_xml(app, app_exec) ?
 #endif
 		AST_MODULE_LOAD_DECLINE : AST_MODULE_LOAD_SUCCESS;
 
 #if defined _AST_VER_1_4
 	cfg = ast_config_load(SWIFT_CONFIG_FILE);
-#elif (defined _AST_VER_1_6 || defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13)
+#elif (defined _AST_VER_1_6 || defined _AST_VER_1_8 || defined _AST_VER_10 || defined _AST_VER_11 || defined _AST_VER_12 || defined _AST_VER_13 || defined _AST_VER_14)
 	cfg = ast_config_load(SWIFT_CONFIG_FILE, config_flags);
 #endif
 


### PR DESCRIPTION
Apparently app_swift, in it's current form won't compile in asterisk 14. 

Here's a patch that seems to allow it to at least compile.